### PR TITLE
Updating the readme outline (Deployment Workflow and Get Started sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ The general flow will be as follows:
 
 **Part 3 - Integrate Azure Stack HCI 20H2 with Azure**: In this step, you'll use **Windows Admin Center** to register your Azure Stacl HCI Cluster with Azure and explore what's presented in the portal
 
-**Part 4 - Deploy your AKS-HCI infrastructure**: In this step, you'll use **Windows Admin Center** to deploy AKS on Azure Stack HCI - this will consist of first deploying the necessary management cluster, then followed by a target cluster, for running workloads.
+**Part 4 - Explore the management of your Azure Stack HCI 20H2 environment**: In this step, you will Explore the management of your Azure Stack HCI 20H2 environment
 
-**Part 5 - Explore AKS on Azure Stack HCI Environment**: With your deployment completed, you're now ready to explore many of the aspects within AKS on Azure Stack HCI. We'll also provide links to further scenarios and resources to continue your learning.
+**Part 5 - Deploy your AKS-HCI infrastructure**: In this step, you'll use **Windows Admin Center** to deploy AKS on Azure Stack HCI - this will consist of first deploying the necessary management cluster, then followed by a target cluster, for running workloads.
+
+**Part 6 - Explore AKS on Azure Stack HCI Environment**: With your deployment completed, you're now ready to explore many of the aspects within AKS on Azure Stack HCI. We'll also provide links to further scenarios and resources to continue your learning.
 
 Get started
 -----------

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Get started
 * [**Part 1** - Complete the prerequisites - deploy your Azure VM](/steps/1_DeployAzureVM.md "Complete the prerequisites - deploy your Azure VM")
 * [**Part 2** - Configure your Azure Stack HCI 20H2 Cluster](/steps/2_DeployAzSHCI.md "Configure your Azure Stack HCI 20H2 Cluster")
 * [**Part 3** - Integrate Azure Stack HCI 20H2 with Azure](/steps/3_AzSHCIIntegration.md "Integrate Azure Stack HCI 20H2 with Azure")
-* [**Part 4** - Deploy your AKS-HCI infrastructure](/steps/4_DeployAKSHCI.md "Deploy your AKS-HCI infrastructure")
-* [**Part 5** - Explore the AKS on Azure Stack HCI Environment](/steps/5_ExploreAKSHCI.md "Explore the AKS on Azure Stack HCI Environment")
+* [**Part 4** - Explore the management of your Azure Stack HCI 20H2 environment](/steps/4_ExploreAzSHCI.md "Explore the management of your Azure Stack HCI 20H2 environment")
+* [**Part 5** - Deploy your AKS-HCI infrastructure](/steps/5_DeployAKSHCI.md "Deploy your AKS-HCI infrastructure")
+* [**Part 6** - Explore the AKS on Azure Stack HCI Environment](/steps/6_ExploreAKSHCI.md "Explore the AKS on Azure Stack HCI Environment")
 
 Product improvements
 -----------


### PR DESCRIPTION
As i was working though the workshop i realize that the links for part 4 and 5 in the the "Get Started" section are broken. After investigating i noticed that there are 6 steps not 5, therefore i updated the "Deployment Workflow" and "Get Started" sections to included the missing step.